### PR TITLE
use a script to emulate syslog to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
     RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
 
 ADD ./python_unix_socket.py /tmp/python_unix_socket.py
+ADD ./startup.sh /tmp/startup.sh
 
-ENTRYPOINT ["/usr/bin/openshift-router"]
+ENTRYPOINT ["/tmp/startup.sh"]
 
-CMD python /tmp/python_unix_socket.py

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+python /tmp/python_unix_socket.py &
+/usr/bin/openshift-router


### PR DESCRIPTION
Instead of directly running haproxy I think we need to use an intermediate script (startup.sh) to first start the python script (in the background) and then start haproxy.
